### PR TITLE
fixed emb.grad in intrinsic_attention

### DIFF
--- a/nbs/00a_inference.text.ipynb
+++ b/nbs/00a_inference.text.ipynb
@@ -111,7 +111,7 @@
       "text/markdown": [
        "<h4 id=\"LMLearner.get_preds\" class=\"doc_header\"><code>LMLearner.get_preds</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>LMLearner.get_preds</code>(**`x`**:`LMLearner`, **`ds_idx`**=*`1`*, **`dl`**=*`None`*, **`raw_outs`**=*`False`*, **`decoded_loss`**=*`True`*, **`fully_decoded`**=*`False`*, **`cat_dim`**=*`0`*, **`decoder`**=*`'decode_spec_tokens'`*, **\\*\\*`kwargs`**)\n",
+       "> <code>LMLearner.get_preds</code>(**`x`**:`LMLearner`, **`ds_idx`**=*`1`*, **`dl`**=*`None`*, **`raw_outs`**=*`False`*, **`decoded_loss`**=*`True`*, **`fully_decoded`**=*`False`*, **`cat_dim`**=*`0`*, **`decoder`**=*`decode_spec_tokens`*, **\\*\\*`kwargs`**)\n",
        "\n",
        "Get predictions with possible decoding"
       ],
@@ -173,7 +173,7 @@
       "text/markdown": [
        "<h4 id=\"TextLearner.get_preds\" class=\"doc_header\"><code>TextLearner.get_preds</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>TextLearner.get_preds</code>(**`x`**:`TextLearner`, **`ds_idx`**=*`1`*, **`dl`**=*`None`*, **`raw_outs`**=*`False`*, **`decoded_loss`**=*`True`*, **`fully_decoded`**=*`False`*, **`decoder`**=*`'decode_spec_tokens'`*, **\\*\\*`kwargs`**)\n",
+       "> <code>TextLearner.get_preds</code>(**`x`**:`TextLearner`, **`ds_idx`**=*`1`*, **`dl`**=*`None`*, **`raw_outs`**=*`False`*, **`decoded_loss`**=*`True`*, **`fully_decoded`**=*`False`*, **`decoder`**=*`decode_spec_tokens`*, **\\*\\*`kwargs`**)\n",
        "\n",
        "Get predictions with possible decoding"
       ],
@@ -233,7 +233,7 @@
       "text/markdown": [
        "<h4 id=\"LMLearner.predict\" class=\"doc_header\"><code>LMLearner.predict</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>LMLearner.predict</code>(**`x`**:`LMLearner`, **`text`**, **`n_words`**=*`1`*, **`no_unk`**=*`True`*, **`temperature`**=*`1.0`*, **`min_p`**=*`None`*, **`decoder`**=*`'decode_spec_tokens'`*, **`only_last_word`**=*`False`*)\n",
+       "> <code>LMLearner.predict</code>(**`x`**:`LMLearner`, **`text`**, **`n_words`**=*`1`*, **`no_unk`**=*`True`*, **`temperature`**=*`1.0`*, **`min_p`**=*`None`*, **`decoder`**=*`decode_spec_tokens`*, **`only_last_word`**=*`False`*)\n",
        "\n",
        "Predict `n_words` from `text`"
       ],
@@ -295,14 +295,16 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'my name is that the'"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "TypeError",
+     "evalue": "'Tokenizer' object is not subscriptable",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-12-f8e634a5fc9b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mlm_learn\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpredict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'my name is'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mn_words\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0monly_last_word\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-9-dd9683c530e6>\u001b[0m in \u001b[0;36mpredict\u001b[0;34m(x, text, n_words, no_unk, temperature, min_p, decoder, only_last_word)\u001b[0m\n\u001b[1;32m     23\u001b[0m         \u001b[0mnum\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrain_ds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnumericalize\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     24\u001b[0m         \u001b[0mtokens\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mnum\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvocab\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0midxs_all\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0mnum\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvocab\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mBOS\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mPAD\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 25\u001b[0;31m         \u001b[0msep\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrain_ds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtokenizer\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msep\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     26\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0msep\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdecoder\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtokens\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: 'Tokenizer' object is not subscriptable"
+     ]
     }
    ],
    "source": [
@@ -333,7 +335,22 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'Tokenizer' object is not subscriptable",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-15-41bf6b2665f0>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mclasses\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprobs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minps\u001b[0m  \u001b[0;34m=\u001b[0m \u001b[0mlearn\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_preds\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdl\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfully_decoded\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-7-20e9c487499c>\u001b[0m in \u001b[0;36mget_preds\u001b[0;34m(x, ds_idx, dl, raw_outs, decoded_loss, fully_decoded, decoder, **kwargs)\u001b[0m\n\u001b[1;32m     24\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0mouts\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minsert\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mraw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 26\u001b[0;31m     \u001b[0;32mif\u001b[0m \u001b[0mfully_decoded\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mouts\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_decode_texts\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdls\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minps\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mouts\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecoder\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdecoder\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     27\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mdecoded_loss\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mouts\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_decode_loss\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcategorize\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvocab\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdec_out\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mouts\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     28\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mouts\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-4-9e6e51496cb4>\u001b[0m in \u001b[0;36m_decode_texts\u001b[0;34m(dl, texts, outs, decoder)\u001b[0m\n\u001b[1;32m     11\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtext\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mTensorText\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m                 \u001b[0;32mfor\u001b[0m \u001b[0mtext\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mbatch\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 13\u001b[0;31m                     \u001b[0mdec_texts\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_inner\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtext\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mnum\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mdl\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     14\u001b[0m     \u001b[0mouts\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minsert\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mouts\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdec_texts\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     15\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mouts\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-4-9e6e51496cb4>\u001b[0m in \u001b[0;36m_inner\u001b[0;34m(o, num, dl)\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_inner\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mo\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mnum\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mdl\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m         \u001b[0mtokens\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mnum\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvocab\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mo\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0mnum\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvocab\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mBOS\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mPAD\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 7\u001b[0;31m         \u001b[0msep\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdataset\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtokenizer\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msep\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      8\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0msep\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdecoder\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtokens\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0mbatch\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mtexts\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: 'Tokenizer' object is not subscriptable"
+     ]
+    }
+   ],
    "source": [
     "classes, probs, inps  = learn.get_preds(dl=dl, fully_decoded=True)"
    ]
@@ -404,12 +421,13 @@
     "    dl = learn.dls.test_dl([text])\n",
     "    batch = next(iter(dl))[0]\n",
     "    emb = learn.model[0].module.encoder(batch).detach().requires_grad_(True)\n",
+    "    emb.retain_grad()\n",
     "    lstm = learn.model[0].module(emb, True)\n",
     "    learn.model.eval()\n",
     "    cl = learn.model[1]((lstm, torch.zeros_like(batch).bool(),))[0].softmax(dim=-1)\n",
     "    if class_id is None: class_id = cl.argmax()\n",
     "    cl[0][class_id].backward()\n",
-    "    attn = emb.squeeze().abs().sum(dim=-1)\n",
+    "    attn = emb.grad.squeeze().abs().sum(dim=-1)\n",
     "    attn /= attn.max()\n",
     "    tok, _ = learn.dls.decode_batch((*tuplify(batch), *tuplify(cl)))[0]\n",
     "    return tok, attn"
@@ -434,7 +452,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"TextLearner.intrinsic_attention\" class=\"doc_header\"><code>TextLearner.intrinsic_attention</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>TextLearner.intrinsic_attention</code>(**`x`**:`TextLearner`, **`text`**:`str`, **`class_id`**:`int`=*`None`*, **\\*\\*`kwargs`**)\n",
+       "\n",
+       "Shows the `intrinsic attention for `text`, optional `class_id`"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "show_doc(TextLearner.intrinsic_attention)"
    ]
@@ -443,7 +478,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-family: monospace;\"><span title=\"0.556\" style=\"background-color: rgba(233, 245, 161, 0.5);\">xxbos</span> <span title=\"0.283\" style=\"background-color: rgba(251, 162, 91, 0.5);\">xxmaj</span> <span title=\"0.873\" style=\"background-color: rgba(45, 161, 84, 0.5);\">batman</span> <span title=\"0.301\" style=\"background-color: rgba(252, 172, 96, 0.5);\">is</span> <span title=\"1.000\" style=\"background-color: rgba(0, 104, 55, 0.5);\">rich</span></span>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "learn.intrinsic_attention('Batman is rich')"
    ]


### PR DESCRIPTION
Fix for issue https://github.com/muellerzr/fastinference/issues/31

Compared to https://github.com/fastai/fastai1/blob/master/fastai/text/interpret.py

attn = emb.**grad**.squeeze().abs().sum(dim=-1) <- grad was missing what lead to the same visualizations for all class_ids.

I guess pytorch changed in the meantime - adding `emb.retain_grad()` was required to get the gradients for the embedding layer.

